### PR TITLE
[FIX] Ensure larger media respect the height of the detail view frame.

### DIFF
--- a/src/pages/Gallery/ImageFrame.tsx
+++ b/src/pages/Gallery/ImageFrame.tsx
@@ -129,6 +129,7 @@ export const ImageFrame: FC<{
           }}
           style={{
             maxWidth: "100%",
+            maxHeight: "100%",
             boxSizing: "border-box",
             display: "block",
             margin: "auto",
@@ -153,6 +154,7 @@ export const ImageFrame: FC<{
           }}
           style={{
             maxWidth: "100%",
+            maxHeight: "100%",
             boxSizing: "border-box",
             display: "block",
             margin: "auto",

--- a/src/pages/GalleryDetail/GalleryDetail.style.tsx
+++ b/src/pages/GalleryDetail/GalleryDetail.style.tsx
@@ -49,7 +49,12 @@ export const BigNftDisplay = withTheme(
             <Loading />
           </Center>
         )}
-        <Tilt gyroscope={false} tiltMaxAngleX={10} tiltMaxAngleY={10}>
+        <Tilt
+          gyroscope={false}
+          tiltMaxAngleX={10}
+          tiltMaxAngleY={10}
+          style={{ maxHeight: "100%" }}
+        >
           <ImageFrame
             type={type}
             onDimensionsKnown={setDimensions}
@@ -60,6 +65,7 @@ export const BigNftDisplay = withTheme(
               opacity: dimensions ? 1 : 0,
               ...(!dimensions && { transform: "translateY(-200vh)" }),
               transition: "opacity 300ms ease-in-out",
+              height: "100%",
               backgroundColor: theme.colors.nftDetailFrame,
             }}
           />


### PR DESCRIPTION
Larger images and videos were bursting out of the frame and not respecting the height. This should fix the issue.