### PR TITLE
Fix/remove usdt from zksync ramp assets

### DIFF
--- a/src/libs/ramp.ts
+++ b/src/libs/ramp.ts
@@ -25,8 +25,8 @@ export const showRampPromise = ({
           ? hasZkSync
             ? RAMP_ASSETS_ZKSYNC
             : RAMP_ASSETS_MAINNET
-          : hasZkSync
-          ? "ZKSYNC_ETH,ZKSYNC_DAI,ZKSYNC_USDC,ZKSYNC_WBTC"
+          : hasZkSync // on non-mainnet networks ramp only supports ETH
+          ? "ZKSYNC_ETH"
           : "ETH",
       userAddress: walletAddress,
       ...(REACT_APP_RAMP_API_KEY && {

--- a/src/libs/ramp.ts
+++ b/src/libs/ramp.ts
@@ -27,7 +27,7 @@ export const showRampPromise = ({
             ? RAMP_ASSETS_ZKSYNC
             : RAMP_ASSETS_MAINNET
           : hasZkSync
-          ? "ZKSYNC_ETH"
+          ? "ZKSYNC_ETH,ZKSYNC_DAI,ZKSYNC_USDC,ZKSYNC_WBTC"
           : "ETH",
       userAddress: walletAddress,
       ...(REACT_APP_RAMP_API_KEY && {

--- a/src/libs/ramp.ts
+++ b/src/libs/ramp.ts
@@ -10,8 +10,7 @@ export interface RampOptions {
 const { REACT_APP_RAMP_API_KEY } = process.env
 
 const RAMP_ASSETS_MAINNET = "ETH,USDC,USDT,DAI"
-const RAMP_ASSETS_ZKSYNC =
-  "ZKSYNC_ETH,ZKSYNC_WBTC,ZKSYNC_USDT,ZKSYNC_USDC,ZKSYNC_DAI"
+const RAMP_ASSETS_ZKSYNC = "ZKSYNC_ETH,ZKSYNC_WBTC,ZKSYNC_USDC,ZKSYNC_DAI"
 
 export const showRampPromise = ({
   walletAddress,


### PR DESCRIPTION
Apologies for the double commit. The first one only edited Ropsten assets.